### PR TITLE
Add ArbitrageEngine pseudocode outline

### DIFF
--- a/ArbitrageEngine.py
+++ b/ArbitrageEngine.py
@@ -1,1 +1,65 @@
+# ArbitrageEngine - Pseudocode Outline
+#
+# This module sketches out the design of a personal AI tool that scans
+# various public marketplaces looking for arbitrage opportunities.
+# It illustrates how the engine could be organized in Python.
 
+class ArbitrageEngine:
+    """High level pseudocode for the arbitrage detection engine."""
+
+    def __init__(self, search_terms, refresh_interval=60, alert_callback=None):
+        # Store search settings supplied by the user
+        self.search_terms = search_terms  # e.g. categories or keywords
+        self.refresh_interval = refresh_interval  # how often to scan markets
+        self.alert_callback = alert_callback  # function to run on a detected deal
+
+        # Placeholder for fetched listings and other internal state
+        self.marketplaces = [
+            "facebook",
+            "ebay",
+            "craigslist",
+            "aliexpress",
+        ]
+
+    def fetch_listings(self):
+        """Fetch listings from each marketplace."""
+        # For each configured marketplace, perform a search based on search_terms.
+        # Pseudocode:
+        # for market in self.marketplaces:
+        #     results = query_marketplace(market, self.search_terms)
+        #     for listing in results:
+        #         yield listing
+        pass
+
+    def evaluate_deals(self, listings):
+        """Evaluate listings to find underpriced items."""
+        # Iterate over the collected listings, compare the listed price with
+        # an estimated fair market value. Example approach:
+        # for listing in listings:
+        #     predicted_price = predict_resale_value(listing)
+        #     if listing.price < predicted_price * 0.5:
+        #         yield listing, predicted_price
+        pass
+
+    def alert(self, listing, predicted_price):
+        """Notify the user about a potential arbitrage opportunity."""
+        # Basic placeholder: print the deal. In a real application, this could
+        # send an email, push notification, etc.
+        if self.alert_callback:
+            self.alert_callback(listing, predicted_price)
+        else:
+            print(f"Deal found: {listing} (est. value ${predicted_price})")
+
+    def run(self):
+        """Continuously monitor marketplaces for deals."""
+        # while True:
+        #     listings = list(self.fetch_listings())
+        #     for listing, price in self.evaluate_deals(listings):
+        #         self.alert(listing, price)
+        #     sleep(self.refresh_interval)
+        pass
+
+# Example usage (would normally be placed under a `if __name__ == "__main__":` guard)
+# search_terms = ["iphone 12"]
+# engine = ArbitrageEngine(search_terms)
+# engine.run()


### PR DESCRIPTION
## Summary
- provide a high-level pseudocode skeleton in `ArbitrageEngine.py`

## Testing
- `python test.py; echo done`

------
https://chatgpt.com/codex/tasks/task_e_687baada79a48324a16e65a88561048d