### PR TITLE
Support custom marketplace selection in CLI

### DIFF
--- a/ArbitrageEngine.py
+++ b/ArbitrageEngine.py
@@ -11,19 +11,40 @@ from urllib.parse import quote_plus
 class ArbitrageEngine:
     """High level pseudocode for the arbitrage detection engine."""
 
-    def __init__(self, search_terms, refresh_interval=60, alert_callback=None):
+    def __init__(
+        self,
+        search_terms,
+        refresh_interval=60,
+        alert_callback=None,
+        marketplaces=None,
+    ):
+        """Create a new engine instance.
+
+        Parameters
+        ----------
+        search_terms : list[str]
+            Keywords to search for on each marketplace.
+        refresh_interval : int, optional
+            How often to poll the marketplaces, by default ``60``.
+        alert_callback : callable | None, optional
+            Optional callback invoked when a deal is found.
+        marketplaces : Iterable[str] | None, optional
+            Restrict queries to these marketplaces. If ``None`` all
+            known marketplaces will be queried.
+        """
+
         # Store search settings supplied by the user
         self.search_terms = search_terms  # e.g. categories or keywords
         self.refresh_interval = refresh_interval  # how often to scan markets
         self.alert_callback = alert_callback  # function to run on a detected deal
 
-        # Placeholder for fetched listings and other internal state
-        self.marketplaces = [
+        default_markets = [
             "facebook",
             "ebay",
             "craigslist",
             "aliexpress",
         ]
+        self.marketplaces = list(marketplaces) if marketplaces else default_markets
 
     # ------------------------------------------------------------------
     # Marketplace query helpers
@@ -156,10 +177,26 @@ def main() -> None:
         default=60,
         help="How often to scan the marketplaces in seconds.",
     )
+    parser.add_argument(
+        "--marketplaces",
+        action="append",
+        help=(
+            "Limit scans to these marketplaces. Can be specified multiple "
+            "times or as a comma separated list."
+        ),
+    )
     args = parser.parse_args()
 
+    marketplaces = None
+    if args.marketplaces:
+        marketplaces = []
+        for entry in args.marketplaces:
+            marketplaces.extend([m for m in entry.split(",") if m])
+
     engine = ArbitrageEngine(
-        args.search_terms, refresh_interval=args.refresh_interval
+        args.search_terms,
+        refresh_interval=args.refresh_interval,
+        marketplaces=marketplaces,
     )
     engine.run()
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # ArbitrageEngine
+
+A small demonstration project showing how one might build a tool to scan
+online marketplaces for potential arbitrage opportunities.
+
+## Usage
+
+```bash
+python ArbitrageEngine.py SEARCH_TERMS [SEARCH_TERMS ...] [--refresh-interval SECONDS] [--marketplaces SITE[,SITE...]]
+```
+
+The optional `--marketplaces` flag limits scanning to the specified
+sites. It can be provided multiple times or as a comma separated list.
+
+```
+python ArbitrageEngine.py phone --marketplaces ebay,craigslist --marketplaces facebook
+```

--- a/test.py
+++ b/test.py
@@ -16,5 +16,38 @@ class EvaluateDealsTest(unittest.TestCase):
         self.assertEqual(deals[0][1], 200)
 
 
+class InitMarketplacesTest(unittest.TestCase):
+    def test_custom_marketplaces(self):
+        engine = ArbitrageEngine(search_terms=[], marketplaces=["ebay"])
+        self.assertEqual(engine.marketplaces, ["ebay"])
+
+
+class CLIMarketplacesTest(unittest.TestCase):
+    def test_cli_parses_marketplaces(self):
+        import sys
+        from unittest import mock
+
+        argv = [
+            "prog",
+            "item",
+            "--marketplaces",
+            "ebay,craigslist",
+            "--marketplaces",
+            "facebook",
+        ]
+
+        with mock.patch.object(sys, "argv", argv):
+            with mock.patch("ArbitrageEngine.ArbitrageEngine") as AE:
+                from ArbitrageEngine import main
+
+                main()
+                AE.assert_called_once()
+                _, kwargs = AE.call_args
+                self.assertEqual(
+                    kwargs.get("marketplaces"),
+                    ["ebay", "craigslist", "facebook"],
+                )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- allow ArbitrageEngine to accept a `marketplaces` list
- add `--marketplaces` option to CLI
- document marketplace filtering in README
- test new initialization and CLI parsing

## Testing
- `python3 test.py`

------
https://chatgpt.com/codex/tasks/task_e_687bbd24229883249a193e4a9b222b29