### PR TITLE
Make marketplace queries asynchronous

### DIFF
--- a/ArbitrageEngine.py
+++ b/ArbitrageEngine.py
@@ -4,9 +4,11 @@
 # various public marketplaces looking for arbitrage opportunities.
 # It illustrates how the engine could be organized in Python.
 
-import requests
+import asyncio
 from urllib.parse import quote_plus
 from time import sleep
+
+import aiohttp
 
 
 class ArbitrageEngine:
@@ -54,57 +56,72 @@ class ArbitrageEngine:
         """Return a URL encoded query string from the search terms."""
         return "+".join(quote_plus(term) for term in self.search_terms)
 
-    def query_facebook(self):
+    async def query_facebook(self):
         query = self._build_query()
         url = f"https://www.facebook.com/marketplace/search?q={query}"
         try:
-            requests.get(url, timeout=5)
-        except requests.RequestException:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(url, timeout=5) as resp:
+                    await resp.text()
+        except aiohttp.ClientError:
             return []
         return [{"title": f"Facebook listing for {query}", "price": None, "url": url}]
 
-    def query_ebay(self):
+    async def query_ebay(self):
         query = self._build_query()
         url = f"https://www.ebay.com/sch/i.html?_nkw={query}"
         try:
-            requests.get(url, timeout=5)
-        except requests.RequestException:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(url, timeout=5) as resp:
+                    await resp.text()
+        except aiohttp.ClientError:
             return []
         return [{"title": f"eBay listing for {query}", "price": None, "url": url}]
 
-    def query_craigslist(self):
+    async def query_craigslist(self):
         query = self._build_query()
         url = f"https://craigslist.org/search/sss?query={query}"
         try:
-            requests.get(url, timeout=5)
-        except requests.RequestException:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(url, timeout=5) as resp:
+                    await resp.text()
+        except aiohttp.ClientError:
             return []
         return [{"title": f"Craigslist listing for {query}", "price": None, "url": url}]
 
-    def query_aliexpress(self):
+    async def query_aliexpress(self):
         query = self._build_query()
         url = f"https://www.aliexpress.com/wholesale?SearchText={query}"
         try:
-            requests.get(url, timeout=5)
-        except requests.RequestException:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(url, timeout=5) as resp:
+                    await resp.text()
+        except aiohttp.ClientError:
             return []
         return [{"title": f"AliExpress listing for {query}", "price": None, "url": url}]
 
-    def fetch_listings(self):
-        """Fetch listings from each marketplace."""
+    async def fetch_listings(self):
+        """Fetch listings from each marketplace concurrently."""
+        tasks = []
         for market in self.marketplaces:
             query_func = getattr(self, f"query_{market}", None)
-            if not query_func:
-                continue
-            results = query_func()
-            for listing in results:
-                # ensure the listing has at least title, price, and url
-                normalized = {
-                    "title": listing.get("title"),
-                    "price": listing.get("price"),
-                    "url": listing.get("url"),
-                }
-                yield normalized
+            if query_func:
+                tasks.append(asyncio.create_task(query_func()))
+
+        listings = []
+        if tasks:
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            for result in results:
+                if isinstance(result, Exception):
+                    continue
+                for listing in result:
+                    normalized = {
+                        "title": listing.get("title"),
+                        "price": listing.get("price"),
+                        "url": listing.get("url"),
+                    }
+                    listings.append(normalized)
+        return listings
 
     def evaluate_deals(self, listings):
         """Evaluate listings to find underpriced items."""
@@ -156,7 +173,7 @@ class ArbitrageEngine:
         """Continuously monitor marketplaces for deals."""
         runs = 0
         while True:
-            listings = list(self.fetch_listings())
+            listings = asyncio.run(self.fetch_listings())
             for listing, price in self.evaluate_deals(listings):
                 self.alert(listing, price)
             runs += 1

--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@
 A small demonstration project showing how one might build a tool to scan
 online marketplaces for potential arbitrage opportunities.
 
+## Installation
+
+Install the required dependencies with pip:
+
+```bash
+pip install aiohttp
+```
+
 ## Usage
 
 ```bash


### PR DESCRIPTION
## Summary
- use `aiohttp` for async HTTP requests
- gather marketplace queries concurrently
- run async code from `run`
- document dependency install in README

## Testing
- `python test.py`
- `pytest -q` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_687bc270061c83248a6036ec2527ccd6