### PR TITLE
Implement price scraping with BeautifulSoup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,11 @@ sites. It can be provided multiple times or as a comma separated list.
 ```
 python ArbitrageEngine.py phone --marketplaces ebay,craigslist --marketplaces facebook
 ```
+
+## Dependencies
+
+Install the required libraries before running the engine:
+
+```bash
+pip install requests beautifulsoup4
+```

--- a/test.py
+++ b/test.py
@@ -22,6 +22,26 @@ class InitMarketplacesTest(unittest.TestCase):
         self.assertEqual(engine.marketplaces, ["ebay"])
 
 
+class PriceExtractionTest(unittest.TestCase):
+    def test_extract_first_price(self):
+        engine = ArbitrageEngine(search_terms=[])
+        html = "<div><span>$19.99</span></div>"
+        self.assertEqual(engine._extract_first_price(html), 19.99)
+
+    def test_query_uses_extracted_price(self):
+        from unittest import mock
+
+        engine = ArbitrageEngine(search_terms=["phone"])
+        fake_response = mock.Mock()
+        fake_response.text = "<span>$42</span>"
+        fake_response.raise_for_status.return_value = None
+
+        with mock.patch("ArbitrageEngine.requests.get", return_value=fake_response):
+            listings = engine.query_ebay()
+
+        self.assertEqual(listings[0]["price"], 42.0)
+
+
 class CLIMarketplacesTest(unittest.TestCase):
     def test_cli_parses_marketplaces(self):
         import sys


### PR DESCRIPTION
## Summary
- parse listing pages using BeautifulSoup in each `query_*` method
- return empty lists on network or parsing errors
- expose helper `_extract_first_price` for simple price extraction
- document BeautifulSoup dependency
- test price extraction and query integration

## Testing
- `python test.py 2>&1 | tail -n 5`

------
https://chatgpt.com/codex/tasks/task_e_687bc271d4ac83249b959afa23798621