### PR TITLE
Add configurable deal threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,14 @@ online marketplaces for potential arbitrage opportunities.
 ## Usage
 
 ```bash
-python ArbitrageEngine.py SEARCH_TERMS [SEARCH_TERMS ...] [--refresh-interval SECONDS] [--marketplaces SITE[,SITE...]]
+python ArbitrageEngine.py SEARCH_TERMS [SEARCH_TERMS ...] [--refresh-interval SECONDS] [--marketplaces SITE[,SITE...]] [--deal-threshold PERCENT]
 ```
 
 The optional `--marketplaces` flag limits scanning to the specified
 sites. It can be provided multiple times or as a comma separated list.
+
+Use `--deal-threshold` to adjust what percentage of the predicted value
+is considered a bargain. The default is `0.5`.
 
 ```
 python ArbitrageEngine.py phone --marketplaces ebay,craigslist --marketplaces facebook

--- a/test.py
+++ b/test.py
@@ -15,6 +15,16 @@ class EvaluateDealsTest(unittest.TestCase):
         self.assertEqual(deals[0][0]["title"], "cheap phone")
         self.assertEqual(deals[0][1], 200)
 
+    def test_custom_threshold_detection(self):
+        engine = ArbitrageEngine(search_terms=[], deal_threshold=0.7)
+        listings = [
+            {"title": "under threshold", "price": 60, "market_value": 100},
+            {"title": "above threshold", "price": 80, "market_value": 100},
+        ]
+        deals = list(engine.evaluate_deals(listings))
+        self.assertEqual(len(deals), 1)
+        self.assertEqual(deals[0][0]["title"], "under threshold")
+
 
 class InitMarketplacesTest(unittest.TestCase):
     def test_custom_marketplaces(self):
@@ -47,6 +57,28 @@ class CLIMarketplacesTest(unittest.TestCase):
                     kwargs.get("marketplaces"),
                     ["ebay", "craigslist", "facebook"],
                 )
+
+
+class CLIThresholdTest(unittest.TestCase):
+    def test_cli_parses_threshold(self):
+        import sys
+        from unittest import mock
+
+        argv = [
+            "prog",
+            "item",
+            "--deal-threshold",
+            "0.25",
+        ]
+
+        with mock.patch.object(sys, "argv", argv):
+            with mock.patch("ArbitrageEngine.ArbitrageEngine") as AE:
+                from ArbitrageEngine import main
+
+                main()
+                AE.assert_called_once()
+                _, kwargs = AE.call_args
+                self.assertEqual(kwargs.get("deal_threshold"), 0.25)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow configuring what percent of market value triggers an alert
- expose new `--deal-threshold` CLI option
- document new argument and explain usage
- test threshold behaviour and CLI parsing

## Testing
- `python test.py -v`

------
https://chatgpt.com/codex/tasks/task_e_687bc2732cf8832487b141e1bb2ce18c