### PR TITLE
Add logging to ArbitrageEngine

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,14 @@ online marketplaces for potential arbitrage opportunities.
 ## Usage
 
 ```bash
-python ArbitrageEngine.py SEARCH_TERMS [SEARCH_TERMS ...] [--refresh-interval SECONDS] [--marketplaces SITE[,SITE...]]
+python ArbitrageEngine.py SEARCH_TERMS [SEARCH_TERMS ...] [--refresh-interval SECONDS] [--marketplaces SITE[,SITE...]] [--log-level LEVEL]
 ```
 
 The optional `--marketplaces` flag limits scanning to the specified
 sites. It can be provided multiple times or as a comma separated list.
+
+`--log-level` controls the verbosity of output. Valid values are the standard
+Python logging levels such as `INFO` or `DEBUG`.
 
 ```
 python ArbitrageEngine.py phone --marketplaces ebay,craigslist --marketplaces facebook


### PR DESCRIPTION
## Summary
- add module logger and expose log level setting
- expose CLI `--log-level` option and document it
- log when alerting instead of printing

## Testing
- `python test.py`

------
https://chatgpt.com/codex/tasks/task_e_687bc2c3c0848324a062ae7bb36d3e1b