### PR TITLE
Add CSV output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,9 @@ sites. It can be provided multiple times or as a comma separated list.
 ```
 python ArbitrageEngine.py phone --marketplaces ebay,craigslist --marketplaces facebook
 ```
+
+Use the `--output-csv` option to append discovered deals to a CSV file:
+
+```
+python ArbitrageEngine.py phone --output-csv deals.csv
+```

--- a/test.py
+++ b/test.py
@@ -49,5 +49,41 @@ class CLIMarketplacesTest(unittest.TestCase):
                 )
 
 
+class AlertCsvTest(unittest.TestCase):
+    def test_alert_appends_csv(self):
+        import csv
+        import os
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            path = tmp.name
+
+        try:
+            engine = ArbitrageEngine(search_terms=[], csv_file=path)
+            engine.alert({"title": "x"}, 1)
+            with open(path, newline="") as fh:
+                rows = list(csv.reader(fh))
+            self.assertEqual(rows[-1], ["{'title': 'x'}", "1"])
+        finally:
+            os.remove(path)
+
+
+class CLIOutputCsvTest(unittest.TestCase):
+    def test_cli_parses_output_csv(self):
+        import sys
+        from unittest import mock
+
+        argv = ["prog", "item", "--output-csv", "file.csv"]
+
+        with mock.patch.object(sys, "argv", argv):
+            with mock.patch("ArbitrageEngine.ArbitrageEngine") as AE:
+                from ArbitrageEngine import main
+
+                main()
+                AE.assert_called_once()
+                _, kwargs = AE.call_args
+                self.assertEqual(kwargs.get("csv_file"), "file.csv")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- support saving deals to CSV with a `csv_file` setting
- allow CLI argument `--output-csv` to enable CSV export
- document the new feature in the README
- test CSV output and CLI parsing

## Testing
- `python -m unittest -v`

------
https://chatgpt.com/codex/tasks/task_e_687bc2c427ec83248116cbbe68a49ab7