### PR TITLE
Add config file parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ online marketplaces for potential arbitrage opportunities.
 
 ```bash
 python ArbitrageEngine.py SEARCH_TERMS [SEARCH_TERMS ...] [--refresh-interval SECONDS] [--marketplaces SITE[,SITE...]]
+python ArbitrageEngine.py --config PATH [--refresh-interval SECONDS] [--marketplaces SITE[,SITE...]] SEARCH_TERMS
 ```
 
 The optional `--marketplaces` flag limits scanning to the specified
@@ -15,3 +16,15 @@ sites. It can be provided multiple times or as a comma separated list.
 ```
 python ArbitrageEngine.py phone --marketplaces ebay,craigslist --marketplaces facebook
 ```
+
+### Configuration file
+
+Use the `--config` option to load default options from a JSON or YAML file. CLI
+arguments override values in the configuration:
+
+```bash
+python ArbitrageEngine.py --config sample_config.yaml
+```
+
+The repository includes `sample_config.yaml` demonstrating the available
+options.

--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -1,0 +1,8 @@
+search_terms:
+  - phone
+  - laptop
+marketplaces:
+  - ebay
+  - craigslist
+refresh_interval: 120
+deal_threshold: 0.4


### PR DESCRIPTION
## Summary
- allow `--config` option to specify a JSON/YAML file
- implement `load_config` helper
- support configurable deal threshold
- merge CLI options with configuration file
- add example `sample_config.yaml`
- document new option in README
- test config merge behaviour

## Testing
- `python test.py`

------
https://chatgpt.com/codex/tasks/task_e_687bc2c60d6483249531d55d914c985a