### PR TITLE
Add CLI iterations option and tests

### DIFF
--- a/ArbitrageEngine.py
+++ b/ArbitrageEngine.py
@@ -214,6 +214,12 @@ def main() -> None:
         default=0.5,
         help="Percentage of predicted value below which a listing is considered a deal.",
     )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=None,
+        help="Number of scan iterations to run before exiting.",
+    )
     args = parser.parse_args()
 
     marketplaces = None
@@ -228,7 +234,7 @@ def main() -> None:
         marketplaces=marketplaces,
         deal_threshold=args.deal_threshold,
     )
-    engine.run()
+    engine.run(iterations=args.iterations)
 
 
 if __name__ == "__main__":

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ pip install aiohttp
 ## Usage
 
 ```bash
-python ArbitrageEngine.py SEARCH_TERMS [SEARCH_TERMS ...] [--refresh-interval SECONDS] [--marketplaces SITE[,SITE...]] [--deal-threshold PERCENT]
+python ArbitrageEngine.py SEARCH_TERMS [SEARCH_TERMS ...] [--refresh-interval SECONDS] [--marketplaces SITE[,SITE...]] [--deal-threshold PERCENT] [--iterations N]
 ```
 
 The optional `--marketplaces` flag limits scanning to the specified
@@ -22,6 +22,8 @@ sites. It can be provided multiple times or as a comma separated list.
 
 Use `--deal-threshold` to adjust what percentage of the predicted value
 is considered a bargain. The default is `0.5`.
+
+Use `--iterations` to run the engine for a specific number of scans before exiting.
 
 ```
 python ArbitrageEngine.py phone --marketplaces ebay,craigslist --marketplaces facebook

--- a/test.py
+++ b/test.py
@@ -81,5 +81,27 @@ class CLIThresholdTest(unittest.TestCase):
                 self.assertEqual(kwargs.get("deal_threshold"), 0.25)
 
 
+class CLIIterationsTest(unittest.TestCase):
+    def test_cli_forwards_iterations(self):
+        import sys
+        from unittest import mock
+
+        argv = [
+            "prog",
+            "item",
+            "--iterations",
+            "3",
+        ]
+
+        with mock.patch.object(sys, "argv", argv):
+            with mock.patch("ArbitrageEngine.ArbitrageEngine") as AE:
+                instance = AE.return_value
+                from ArbitrageEngine import main
+
+                main()
+                AE.assert_called_once()
+                instance.run.assert_called_once_with(iterations=3)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- allow setting number of iterations from CLI
- document new `--iterations` option in README
- unit test to verify CLI passes `iterations` to `ArbitrageEngine`

## Testing
- `python test.py`

------
https://chatgpt.com/codex/tasks/task_e_687bed9e7fbc8324acb912893fad2de3