### PR TITLE
Make run async and adapt CLI

### DIFF
--- a/ArbitrageEngine.py
+++ b/ArbitrageEngine.py
@@ -6,7 +6,6 @@
 
 import asyncio
 from urllib.parse import quote_plus
-from time import sleep
 
 import aiohttp
 
@@ -182,17 +181,17 @@ class ArbitrageEngine:
         else:
             print(f"Deal found: {listing} (est. value ${predicted_price})")
 
-    def run(self, iterations=None):
+    async def run(self, iterations=None):
         """Continuously monitor marketplaces for deals."""
         runs = 0
         while True:
-            listings = asyncio.run(self.fetch_listings())
+            listings = await self.fetch_listings()
             for listing, price in self.evaluate_deals(listings):
                 self.alert(listing, price)
             runs += 1
             if iterations is not None and runs >= iterations:
                 break
-            sleep(self.refresh_interval)
+            await asyncio.sleep(self.refresh_interval)
 
 
 def main() -> None:
@@ -245,7 +244,7 @@ def main() -> None:
         marketplaces=marketplaces,
         deal_threshold=args.deal_threshold,
     )
-    engine.run(iterations=args.iterations)
+    asyncio.run(engine.run(iterations=args.iterations))
 
 
 if __name__ == "__main__":

--- a/test_arbitrageengine.py
+++ b/test_arbitrageengine.py
@@ -61,16 +61,17 @@ class CLIMarketplacesTest(unittest.TestCase):
         ]
 
         with mock.patch.object(sys, "argv", argv):
-            with mock.patch("ArbitrageEngine.ArbitrageEngine") as AE:
-                from ArbitrageEngine import main
+            with mock.patch("ArbitrageEngine.asyncio.run") as aiorun:
+                with mock.patch("ArbitrageEngine.ArbitrageEngine") as AE:
+                    from ArbitrageEngine import main
 
-                main()
-                AE.assert_called_once()
-                _, kwargs = AE.call_args
-                self.assertEqual(
-                    kwargs.get("marketplaces"),
-                    ["ebay", "craigslist", "facebook"],
-                )
+                    main()
+                    AE.assert_called_once()
+                    _, kwargs = AE.call_args
+                    self.assertEqual(
+                        kwargs.get("marketplaces"),
+                        ["ebay", "craigslist", "facebook"],
+                    )
 
 
 class CLIThresholdTest(unittest.TestCase):
@@ -86,13 +87,14 @@ class CLIThresholdTest(unittest.TestCase):
         ]
 
         with mock.patch.object(sys, "argv", argv):
-            with mock.patch("ArbitrageEngine.ArbitrageEngine") as AE:
-                from ArbitrageEngine import main
+            with mock.patch("ArbitrageEngine.asyncio.run") as aiorun:
+                with mock.patch("ArbitrageEngine.ArbitrageEngine") as AE:
+                    from ArbitrageEngine import main
 
-                main()
-                AE.assert_called_once()
-                _, kwargs = AE.call_args
-                self.assertEqual(kwargs.get("deal_threshold"), 0.25)
+                    main()
+                    AE.assert_called_once()
+                    _, kwargs = AE.call_args
+                    self.assertEqual(kwargs.get("deal_threshold"), 0.25)
 
 
 class CLIRefreshIntervalTest(unittest.TestCase):
@@ -108,13 +110,14 @@ class CLIRefreshIntervalTest(unittest.TestCase):
         ]
 
         with mock.patch.object(sys, "argv", argv):
-            with mock.patch("ArbitrageEngine.ArbitrageEngine") as AE:
-                from ArbitrageEngine import main
+            with mock.patch("ArbitrageEngine.asyncio.run") as aiorun:
+                with mock.patch("ArbitrageEngine.ArbitrageEngine") as AE:
+                    from ArbitrageEngine import main
 
-                main()
-                AE.assert_called_once()
-                _, kwargs = AE.call_args
-                self.assertEqual(kwargs.get("refresh_interval"), 15)
+                    main()
+                    AE.assert_called_once()
+                    _, kwargs = AE.call_args
+                    self.assertEqual(kwargs.get("refresh_interval"), 15)
 
 
 class CLIIterationsTest(unittest.TestCase):
@@ -130,13 +133,15 @@ class CLIIterationsTest(unittest.TestCase):
         ]
 
         with mock.patch.object(sys, "argv", argv):
-            with mock.patch("ArbitrageEngine.ArbitrageEngine") as AE:
-                instance = AE.return_value
-                from ArbitrageEngine import main
+            with mock.patch("ArbitrageEngine.asyncio.run") as aiorun:
+                with mock.patch("ArbitrageEngine.ArbitrageEngine") as AE:
+                    instance = AE.return_value
+                    from ArbitrageEngine import main
 
-                main()
-                AE.assert_called_once()
-                instance.run.assert_called_once_with(iterations=3)
+                    main()
+                    AE.assert_called_once()
+                    instance.run.assert_called_once_with(iterations=3)
+                    aiorun.assert_called_once_with(instance.run.return_value)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- make `ArbitrageEngine.run` asynchronous
- replace blocking calls with `await` in run
- update CLI to invoke the async run via `asyncio.run`
- adjust CLI tests for new async behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bf6bd29708324a49e44c8ed3aae1a