### PR TITLE
Add Mercari marketplace

### DIFF
--- a/ArbitrageEngine.py
+++ b/ArbitrageEngine.py
@@ -48,6 +48,7 @@ class ArbitrageEngine:
             "ebay",
             "craigslist",
             "aliexpress",
+            "mercari",
         ]
         self.marketplaces = list(marketplaces) if marketplaces else default_markets
 
@@ -111,6 +112,15 @@ class ArbitrageEngine:
         except aiohttp.ClientError:
             return []
         return [{"title": f"AliExpress listing for {query}", "price": None, "url": url}]
+
+    async def query_mercari(self, session: aiohttp.ClientSession):
+        query = self._build_query()
+        url = f"https://www.mercari.com/search/?keyword={query}"
+        try:
+            await self._async_get(url, session)
+        except aiohttp.ClientError:
+            return []
+        return [{"title": f"Mercari listing for {query}", "price": None, "url": url}]
 
     async def fetch_listings(self):
         """Fetch listings from each marketplace concurrently."""

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ python ArbitrageEngine.py SEARCH_TERMS [SEARCH_TERMS ...] [--refresh-interval SE
 
 The optional `--marketplaces` flag limits scanning to the specified
 sites. It can be provided multiple times or as a comma separated list.
+By default the engine queries `facebook`, `ebay`, `craigslist`,
+`aliexpress` and `mercari`.
 
 Use `--deal-threshold` to adjust what percentage of the predicted value
 is considered a bargain. The default is `0.5`.
@@ -26,5 +28,5 @@ is considered a bargain. The default is `0.5`.
 Use `--iterations` to run the engine for a specific number of scans before exiting.
 
 ```
-python ArbitrageEngine.py phone --marketplaces ebay,craigslist --marketplaces facebook
+python ArbitrageEngine.py phone --marketplaces ebay,craigslist --marketplaces mercari
 ```

--- a/test_arbitrageengine.py
+++ b/test_arbitrageengine.py
@@ -45,6 +45,10 @@ class InitMarketplacesTest(unittest.TestCase):
         engine = ArbitrageEngine(search_terms=[], marketplaces=["ebay"])
         self.assertEqual(engine.marketplaces, ["ebay"])
 
+    def test_default_includes_mercari(self):
+        engine = ArbitrageEngine(search_terms=[])
+        self.assertIn("mercari", engine.marketplaces)
+
 
 class CLIMarketplacesTest(unittest.TestCase):
     def test_cli_parses_marketplaces(self):

--- a/test_fetch_listings.py
+++ b/test_fetch_listings.py
@@ -9,6 +9,7 @@ async def test_fetch_listings_combines_results(monkeypatch):
     expected_ebay = [{"title": "from ebay", "price": None, "url": None}]
     expected_craigslist = [{"title": "from craigslist", "price": None, "url": None}]
     expected_aliexpress = [{"title": "from aliexpress", "price": None, "url": None}]
+    expected_mercari = [{"title": "from mercari", "price": None, "url": None}]
 
     async def fake_fb(self, session):
         return expected_fb
@@ -22,14 +23,22 @@ async def test_fetch_listings_combines_results(monkeypatch):
     async def fake_aliexpress(self, session):
         return expected_aliexpress
 
+    async def fake_mercari(self, session):
+        return expected_mercari
+
     monkeypatch.setattr(ArbitrageEngine, "query_facebook", fake_fb)
     monkeypatch.setattr(ArbitrageEngine, "query_ebay", fake_ebay)
     monkeypatch.setattr(ArbitrageEngine, "query_craigslist", fake_craigslist)
     monkeypatch.setattr(ArbitrageEngine, "query_aliexpress", fake_aliexpress)
+    monkeypatch.setattr(ArbitrageEngine, "query_mercari", fake_mercari)
 
     listings = await engine.fetch_listings()
 
     for listing in (
-        expected_fb + expected_ebay + expected_craigslist + expected_aliexpress
+        expected_fb
+        + expected_ebay
+        + expected_craigslist
+        + expected_aliexpress
+        + expected_mercari
     ):
         assert listing in listings


### PR DESCRIPTION
## Summary
- add query_mercari helper and include Mercari in default marketplaces
- update README usage and documentation
- test default marketplaces for Mercari
- ensure listings combine Mercari listings too

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bf4a49c30832487cdc13d60f06e52