### PR TITLE
Document async run

### DIFF
--- a/ArbitrageEngine.py
+++ b/ArbitrageEngine.py
@@ -192,7 +192,12 @@ class ArbitrageEngine:
             print(f"Deal found: {listing} (est. value ${predicted_price})")
 
     async def run(self, iterations=None):
-        """Continuously monitor marketplaces for deals."""
+        """Continuously monitor marketplaces for deals.
+
+        This coroutine repeatedly polls the configured marketplaces,
+        evaluates any discovered listings and then waits for the
+        configured refresh interval before the next scan.
+        """
         runs = 0
         while True:
             listings = await self.fetch_listings()


### PR DESCRIPTION
## Summary
- document `run` coroutine in ArbitrageEngine

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bf81cbec083249539e0e43a5b1e9b