### PR TITLE
Enable real marketplace parsing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 aiohttp
 pytest
 pytest-asyncio
+beautifulsoup4

--- a/test_parsers.py
+++ b/test_parsers.py
@@ -1,0 +1,21 @@
+import unittest
+from ArbitrageEngine import ArbitrageEngine
+
+class FacebookParserTest(unittest.TestCase):
+    def test_parse_facebook_basic(self):
+        html = (
+            '<div><a href="/marketplace/item/123">'
+            '<div class="title">Old Phone</div>'
+            '<span>$50</span>'
+            '</a></div>'
+        )
+        engine = ArbitrageEngine(search_terms=[])
+        listings = engine.parse_facebook(html, base_url="https://www.facebook.com")
+        self.assertEqual(len(listings), 1)
+        listing = listings[0]
+        self.assertEqual(listing["title"], "Old Phone")
+        self.assertEqual(listing["price"], 50.0)
+        self.assertEqual(listing["url"], "https://www.facebook.com/marketplace/item/123")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- parse Facebook Marketplace HTML listings
- parse listings from other marketplaces using BeautifulSoup
- add bs4 dependency
- test Facebook parser

## Testing
- `pip install -r requirements.txt`
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_e_687bfcd76a848324ac9563f36e425d31